### PR TITLE
Add lispmds method to moveTrappedPoints

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -545,8 +545,8 @@ ac_titer_layer_sd <- function(titer_layers, dilution_stepsize) {
     .Call('_Racmacs_ac_titer_layer_sd', PACKAGE = 'Racmacs', titer_layers, dilution_stepsize)
 }
 
-ac_move_trapped_points <- function(optimization, titertable, grid_spacing, options, max_iterations = 10L, dilution_stepsize = 1.0) {
-    .Call('_Racmacs_ac_move_trapped_points', PACKAGE = 'Racmacs', optimization, titertable, grid_spacing, options, max_iterations, dilution_stepsize)
+ac_move_trapped_points <- function(optimization, titertable, grid_spacing, options, max_iterations = 10L, dilution_stepsize = 1.0, method = "racmacs", num_randomizations = 10L, randomize_distance = 20.0) {
+    .Call('_Racmacs_ac_move_trapped_points', PACKAGE = 'Racmacs', optimization, titertable, grid_spacing, options, max_iterations, dilution_stepsize, method, num_randomizations, randomize_distance)
 }
 
 ac_coords_stress <- function(titers, min_colbasis, fixed_colbases, ag_reactivity_adjustments, ag_coords, sr_coords, dilution_stepsize) {

--- a/R/map_optimize.R
+++ b/R/map_optimize.R
@@ -604,6 +604,12 @@ checkHemisphering <- function(
 #'   when searching for more optimal positions
 #' @param max_iterations The maximum number of iterations of searching for
 #'   trapped points then relaxing the map to be performed
+#' @param method Method to use: `"racmacs"` (default) uses a systematic grid
+#'   search; `"lispmds"` uses the LispMDS approach of random perturbations.
+#' @param num_randomizations For `method = "lispmds"`, the number of random
+#'   perturbations to try per antigen.
+#' @param randomize_distance For `method = "lispmds"`, the maximum perturbation
+#'   in each dimension (uniform random draw of up to this distance in either direction).
 #' @param options List of named optimizer options, see `RacOptimizer.options()`
 #'
 #' @returns Returns the acmap object with updated coordinates (if any trapped
@@ -616,6 +622,9 @@ moveTrappedPoints <- function(
   optimization_number = 1,
   grid_spacing = 0.25,
   max_iterations = 10,
+  method = "racmacs",
+  num_randomizations = 10,
+  randomize_distance = 20,
   options = list()
   ) {
 
@@ -626,7 +635,10 @@ moveTrappedPoints <- function(
     grid_spacing = grid_spacing,
     options = do.call(RacOptimizer.options, options),
     max_iterations = max_iterations,
-    dilution_stepsize = dilutionStepsize(map)
+    dilution_stepsize = dilutionStepsize(map),
+    method = method,
+    num_randomizations = as.integer(num_randomizations),
+    randomize_distance = randomize_distance
   )
 
   # Realign optimizations

--- a/man/moveTrappedPoints.Rd
+++ b/man/moveTrappedPoints.Rd
@@ -9,6 +9,9 @@ moveTrappedPoints(
   optimization_number = 1,
   grid_spacing = 0.25,
   max_iterations = 10,
+  method = "racmacs",
+  num_randomizations = 10,
+  randomize_distance = 20,
   options = list()
 )
 }
@@ -22,6 +25,15 @@ when searching for more optimal positions}
 
 \item{max_iterations}{The maximum number of iterations of searching for
 trapped points then relaxing the map to be performed}
+
+\item{method}{Method to use: \code{"racmacs"} (default) uses a systematic grid
+search; \code{"lispmds"} uses the LispMDS approach of random perturbations.}
+
+\item{num_randomizations}{For \code{method = "lispmds"}, the number of random
+perturbations to try per antigen.}
+
+\item{randomize_distance}{For \code{method = "lispmds"}, the maximum perturbation
+in each dimension (uniform random draw of up to this distance in either direction).}
 
 \item{options}{List of named optimizer options, see \code{RacOptimizer.options()}}
 }
@@ -42,12 +54,12 @@ trapped before relaxing the map and searching again, stopping either when no
 more trapped points are found or \code{max_iterations} is reached.
 }
 \seealso{
-Other map optimization functions: 
-\code{\link{RacOptimizer.options}()},
-\code{\link{make.acmap}()},
-\code{\link{optimizeMap}()},
-\code{\link{randomizeCoords}()},
-\code{\link{relaxMapOneStep}()},
-\code{\link{relaxMap}()}
+Other map optimization functions:
+\code{\link[=RacOptimizer.options]{RacOptimizer.options()}},
+\code{\link[=make.acmap]{make.acmap()}},
+\code{\link[=optimizeMap]{optimizeMap()}},
+\code{\link[=randomizeCoords]{randomizeCoords()}},
+\code{\link[=relaxMap]{relaxMap()}},
+\code{\link[=relaxMapOneStep]{relaxMapOneStep()}}
 }
 \concept{map optimization functions}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1532,8 +1532,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // ac_move_trapped_points
-AcOptimization ac_move_trapped_points(AcOptimization optimization, AcTiterTable titertable, double grid_spacing, AcOptimizerOptions options, int max_iterations, double dilution_stepsize);
-RcppExport SEXP _Racmacs_ac_move_trapped_points(SEXP optimizationSEXP, SEXP titertableSEXP, SEXP grid_spacingSEXP, SEXP optionsSEXP, SEXP max_iterationsSEXP, SEXP dilution_stepsizeSEXP) {
+AcOptimization ac_move_trapped_points(AcOptimization optimization, AcTiterTable titertable, double grid_spacing, AcOptimizerOptions options, int max_iterations, double dilution_stepsize, std::string method, int num_randomizations, double randomize_distance);
+RcppExport SEXP _Racmacs_ac_move_trapped_points(SEXP optimizationSEXP, SEXP titertableSEXP, SEXP grid_spacingSEXP, SEXP optionsSEXP, SEXP max_iterationsSEXP, SEXP dilution_stepsizeSEXP, SEXP methodSEXP, SEXP num_randomizationsSEXP, SEXP randomize_distanceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1543,7 +1543,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< AcOptimizerOptions >::type options(optionsSEXP);
     Rcpp::traits::input_parameter< int >::type max_iterations(max_iterationsSEXP);
     Rcpp::traits::input_parameter< double >::type dilution_stepsize(dilution_stepsizeSEXP);
-    rcpp_result_gen = Rcpp::wrap(ac_move_trapped_points(optimization, titertable, grid_spacing, options, max_iterations, dilution_stepsize));
+    Rcpp::traits::input_parameter< std::string >::type method(methodSEXP);
+    Rcpp::traits::input_parameter< int >::type num_randomizations(num_randomizationsSEXP);
+    Rcpp::traits::input_parameter< double >::type randomize_distance(randomize_distanceSEXP);
+    rcpp_result_gen = Rcpp::wrap(ac_move_trapped_points(optimization, titertable, grid_spacing, options, max_iterations, dilution_stepsize, method, num_randomizations, randomize_distance));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2021,7 +2024,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_Racmacs_ac_titer_merge_type", (DL_FUNC) &_Racmacs_ac_titer_merge_type, 1},
     {"_Racmacs_ac_titer_layer_merge_types", (DL_FUNC) &_Racmacs_ac_titer_layer_merge_types, 1},
     {"_Racmacs_ac_titer_layer_sd", (DL_FUNC) &_Racmacs_ac_titer_layer_sd, 2},
-    {"_Racmacs_ac_move_trapped_points", (DL_FUNC) &_Racmacs_ac_move_trapped_points, 6},
+    {"_Racmacs_ac_move_trapped_points", (DL_FUNC) &_Racmacs_ac_move_trapped_points, 9},
     {"_Racmacs_ac_coords_stress", (DL_FUNC) &_Racmacs_ac_coords_stress, 7},
     {"_Racmacs_ac_point_stresses", (DL_FUNC) &_Racmacs_ac_point_stresses, 6},
     {"_Racmacs_ac_point_residuals", (DL_FUNC) &_Racmacs_ac_point_residuals, 2},

--- a/src/ac_move_trapped_points.cpp
+++ b/src/ac_move_trapped_points.cpp
@@ -8,7 +8,90 @@
 
 #include "acmap_optimization.h"
 #include "ac_stress_blobs.h"
+#include "ac_stress.h"
+#include "ac_relax_coords.h"
 #include "ac_optimizer_options.h"
+
+// Stress contribution of one antigen across all sera
+static double calc_ag_stress(
+    int ag,
+    const arma::mat &ag_coords,
+    const arma::mat &sr_coords,
+    const arma::mat &tabledists,
+    const arma::imat &titertypes,
+    double dilution_stepsize
+) {
+  double stress = 0.0;
+  for (arma::uword sr = 0; sr < sr_coords.n_rows; sr++) {
+    arma::sword ttype = titertypes(ag, sr);
+    if (ttype <= 0) continue;
+    double map_dist = arma::norm(arma::vectorise(ag_coords.row(ag) - sr_coords.row(sr)));
+    double td = tabledists(ag, sr);
+    stress += ac_ptStress(map_dist, td, ttype, dilution_stepsize);
+  }
+  return stress;
+}
+
+// LispMDS method: for each antigen, try num_randomizations random perturbations
+// and keep the position with the lowest stress (if lower than original).
+static AcOptimization move_trapped_points_lispmds(
+    AcOptimization optimization,
+    const arma::mat &tabledists,
+    const arma::imat &titertypes,
+    const AcOptimizerOptions &options,
+    int num_randomizations,
+    double randomize_distance,
+    double dilution_stepsize
+) {
+
+  int num_ags = optimization.num_ags();
+  int num_sr  = optimization.num_sr();
+  arma::mat ag_coords = optimization.get_ag_base_coords();
+  arma::mat sr_coords = optimization.get_sr_base_coords();
+  arma::uword ndims   = ag_coords.n_cols;
+
+  // All sera are fixed throughout — only the test antigen is free
+  arma::uvec fixed_sera = arma::regspace<arma::uvec>(0, num_sr - 1);
+
+  for (int ag = 0; ag < num_ags; ag++) {
+
+    double orig_stress = calc_ag_stress(ag, ag_coords, sr_coords, tabledists, titertypes, dilution_stepsize);
+
+    arma::rowvec best_coords = ag_coords.row(ag);
+    double best_stress = orig_stress;
+
+    // All antigens fixed except this one
+    arma::uvec fixed_ags = arma::regspace<arma::uvec>(0, num_ags - 1);
+    fixed_ags.shed_row(ag);
+
+    for (int i = 0; i < num_randomizations; i++) {
+
+      // Perturb uniformly by up to randomize_distance in each dimension
+      arma::mat ag_coords_trial = ag_coords;
+      ag_coords_trial.row(ag) += (arma::randu<arma::rowvec>(ndims) * 2.0 - 1.0) * randomize_distance;
+
+      // Relax only this antigen
+      ac_relax_coords(
+        tabledists, titertypes, ag_coords_trial, sr_coords,
+        options, fixed_ags, fixed_sera, arma::mat(), dilution_stepsize
+      );
+
+      double trial_stress = calc_ag_stress(ag, ag_coords_trial, sr_coords, tabledists, titertypes, dilution_stepsize);
+
+      if (trial_stress < best_stress) {
+        best_stress   = trial_stress;
+        best_coords   = ag_coords_trial.row(ag);
+      }
+    }
+
+    if (best_stress < orig_stress) {
+      ag_coords.row(ag) = best_coords;
+    }
+  }
+
+  optimization.set_ag_base_coords(ag_coords);
+  return optimization;
+}
 
 // Check for trapped antigens
 arma::mat check_ag_trapped_points(
@@ -114,9 +197,26 @@ AcOptimization ac_move_trapped_points(
   double grid_spacing,
   AcOptimizerOptions options,
   int max_iterations = 10,
-  double dilution_stepsize = 1.0
+  double dilution_stepsize = 1.0,
+  std::string method = "racmacs",
+  int num_randomizations = 10,
+  double randomize_distance = 20.0
 ){
 
+
+  // Dispatch to LispMDS method if requested
+  if (method == "lispmds") {
+    arma::imat titertypes_l = titertable.get_titer_types();
+    arma::mat tabledists_l = titertable.numeric_table_distances(
+      optimization.get_min_column_basis(),
+      optimization.get_fixed_column_bases(),
+      optimization.get_ag_reactivity_adjustments()
+    );
+    return move_trapped_points_lispmds(
+      optimization, tabledists_l, titertypes_l, options,
+      num_randomizations, randomize_distance, dilution_stepsize
+    );
+  }
 
   // Check antigen and sera trapped points recursively
   if(options.report_progress) REprintf("Checking for trapped points recursively:");

--- a/tests/testthat/test-map_optimization.R
+++ b/tests/testthat/test-map_optimization.R
@@ -485,6 +485,32 @@ test_that("Moving trapped points", {
 })
 
 
+# Moving trapped points with lispmds method
+map4_lispmds <- map
+largemap4_lispmds <- largemap
+test_that("Moving trapped points with lispmds method", {
+
+  # On a well-optimized map, lispmds should not increase stress
+  map4_lispmds <- relaxMap(map4_lispmds)
+  stress_before <- mapStress(map4_lispmds)
+  map4_lispmds_moved <- moveTrappedPoints(map4_lispmds, method = "lispmds")
+  expect_lte(mapStress(map4_lispmds_moved), stress_before)
+
+  # On a map with trapped points, lispmds should reduce stress
+  largemap4_lispmds <- relaxMap(largemap4_lispmds)
+  largemap4_lispmds_moved <- moveTrappedPoints(largemap4_lispmds, method = "lispmds")
+  expect_lt(
+    mapStress(largemap4_lispmds_moved),
+    mapStress(largemap4_lispmds)
+  )
+
+  # Custom num_randomizations and randomize_distance are accepted
+  result <- moveTrappedPoints(map4_lispmds, method = "lispmds", num_randomizations = 5, randomize_distance = 10)
+  expect_s3_class(result, "acmap")
+
+})
+
+
 # Randomizing coordinates
 test_that("Randomize map coordinates", {
 


### PR DESCRIPTION
Adds method = "lispmds" to moveTrappedPoints(), implementing the LispMDS approach of randomly perturbing each antigen num_randomizations times (default 10) by up to randomize_distance (default 20) in each dimension, relaxing only that antigen, and keeping the position if stress improves. The existing grid-search behaviour is preserved as method = "racmacs" (default).