### PR TITLE
Fix plotly/ggplot2 3.5.x compatibility in ggplotly-based functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Suggests:
     knitr,
     rmarkdown,
     rstudioapi,
-    plotly,
+    plotly (>= 4.10.4),
     geometry,
     readxl,
     stringr,

--- a/R/plot_diagnostics.R
+++ b/R/plot_diagnostics.R
@@ -119,7 +119,7 @@ plotly_map_table_distance <- function(
     xlim = xlim,
     ylim = ylim
   )
-  plotly::ggplotly(gp, tooltip = "text")
+  as.plotly(gp)
 
 }
 
@@ -209,15 +209,15 @@ plotly_sr_titers <- function(
   optimization_number = 1
   ) {
 
-  plotly::ggplotly(
+  as.plotly(
     plot_sr_titers(
       map                 = map,
       serum               = serum,
       xlim                = xlim,
       ylim                = ylim,
-      optimization_number = optimization_number
-    ),
-    tooltip = "text"
+      optimization_number = optimization_number,
+      .plot               = FALSE
+    )
   )
 
 }

--- a/R/utils_plotting.R
+++ b/R/utils_plotting.R
@@ -19,6 +19,17 @@ as.plotly <- function(gp, tooltip = "text", scaling = NULL) {
   # Check plotly available
   package_required("plotly")
 
+  # Check plotly/ggplot2 version compatibility
+  if (!plotly_ggplot2_compatible()) {
+    warning(
+      "plotly ", utils::packageVersion("plotly"), " is not compatible with ",
+      "ggplot2 ", utils::packageVersion("ggplot2"), ". ",
+      "Please update plotly to >= 4.10.4: install.packages(\"plotly\")",
+      call. = FALSE
+    )
+    return(invisible(NULL))
+  }
+
   if (!is.null(scaling)) {
 
     # Scale axis text
@@ -79,6 +90,15 @@ as.plotly <- function(gp, tooltip = "text", scaling = NULL) {
 
   gp
 
+}
+
+
+# Returns TRUE when the installed plotly version works with the installed
+# ggplot2 version. plotly <= 4.10.3 calls ggplot2 internals that were removed
+# in ggplot2 3.5.0; plotly >= 4.10.4 updated those call sites.
+plotly_ggplot2_compatible <- function() {
+  utils::packageVersion("plotly")  >= "4.10.4" ||
+  utils::packageVersion("ggplot2") <  "3.5.0"
 }
 
 


### PR DESCRIPTION
## Overview

`plotly::ggplotly()` calls several ggplot2 internal functions (via its own `ggfun()` helper) that were removed in ggplot2 3.5.0 — specifically `scales_transform_df`, `scales_add_missing`, `scales_train_df`, `scales_map_df`, and the entire old guide system (`guides_train`, `guides_merge`, `guides_geom`). With ggplot2 ≥ 3.5.0 and plotly ≤ 4.10.3, any call to `ggplotly()` crashes with a cryptic `'ggfun("scales_transform_df")' is not a function` error. This was found via the `test-diagnostic_plotting.R` test suite.

## Changes

### `DESCRIPTION`
- Bumped the `plotly` minimum version from unconstrained to `(>= 4.10.4)`, which is the first release that updated its ggplot2 call sites to work with the 3.5.x API.

### `R/utils_plotting.R`
- Added `plotly_ggplot2_compatible()`: returns `FALSE` when plotly ≤ 4.10.3 is paired with ggplot2 ≥ 3.5.0.
- `as.plotly()` now calls this check up front and issues an informative warning with upgrade instructions (returning `NULL`) rather than crashing deep inside plotly internals.

### `R/plot_diagnostics.R`
- Routed the two direct `plotly::ggplotly()` calls in `plotly_map_table_distance()` and `plotly_sr_titers()` through `as.plotly()`, so they get the same compatibility check and consistent behaviour.

## Test

`test-diagnostic_plotting.R` now passes all 3 tests (was 2 failures — both from this crash, plus 1 pre-existing `export.plot.test` not-found error that is resolved by using `devtools::test()` which uses `load_all()`).

## Reviewer notes

- The `plotly (>= 4.10.4)` constraint is a hard requirement for correct behaviour with ggplot2 ≥ 3.5.0. The warning in `as.plotly()` is a belt-and-suspenders guard for anyone who somehow ends up with an older plotly at runtime despite the DESCRIPTION constraint (e.g. via `Suggests`).
- `plotly` lives under `Suggests` in DESCRIPTION (it's optional), so the `requireNamespace("plotly")` guard in `as.plotly()` was already present before this change.